### PR TITLE
Update StableXPair.sol to add a 1% withdrawal fee to keep sticky TVL

### DIFF
--- a/contracts/StableXPair.sol
+++ b/contracts/StableXPair.sol
@@ -158,8 +158,8 @@ contract StableXPair is IStableXPair, StableXERC20 {
         _safeTransfer(address(this)), feeTo, fee);
         _burn(address(this), liquidity.sub(fee);
         // to fix: the logic of safeTransfer
-        _safeTransfer(_token0, to, amount0.div(100).mul(99));
-        _safeTransfer(_token1, to, amount1.div(100).mul(99));
+        _safeTransfer(_token0, to, amount0 * 99 / 100);
+        _safeTransfer(_token1, to, amount1 * 99 / 100);
         } else {
         _burn(address(this), liquidity);
         _safeTransfer(_token0, to, amount0);


### PR DESCRIPTION
Adding a 1% withdrawal fee by reducing the amount send out to withdrawer and sending the 1% LP token to the same feeTo address that receives rewards from trading fees